### PR TITLE
refactor(kafkax): 支持多实例 Kafka producer 的管理

### DIFF
--- a/queue/kafkax/producer.go
+++ b/queue/kafkax/producer.go
@@ -27,11 +27,11 @@ type KafkaConfig struct {
 }
 
 // getPoolKey 构造 producerPool 的 key
-func getPoolKey(c *KafkaConfig, topic string) string {
-	if c.Name == "" {
+func getPoolKey(kafkaName, topic string) string {
+	if kafkaName == "" {
 		return topic // 向后兼容：未设置 Name 时退化为纯 topic
 	}
-	return c.Name + ":" + topic
+	return kafkaName + ":" + topic
 }
 
 type KafkaProducer struct {
@@ -44,7 +44,7 @@ type KafkaProducer struct {
 func InitProducerForTopics(ctx context.Context, c *KafkaConfig, topics []string) {
 	for _, topic := range topics {
 		producer := newKafkaProducerWithTopic(ctx, c, topic)
-		key := getPoolKey(c, topic)
+		key := getPoolKey(c.Name, topic)
 		producerPool.LoadOrStore(key, producer)
 		fmt.Println("Kafka producer initialized for topic:", topic)
 	}
@@ -83,8 +83,8 @@ func newKafkaProducerWithTopic(ctx context.Context, c *KafkaConfig, topic string
 }
 
 // GetProducerByTopic 获取指定 topic 的 producer
-func GetProducerByTopic(c *KafkaConfig, topic string) (*KafkaProducer, error) {
-	key := getPoolKey(c, topic)
+func GetProducerByTopic(kafkaName, topic string) (*KafkaProducer, error) {
+	key := getPoolKey(kafkaName, topic)
 	val, ok := producerPool.Load(key)
 	if !ok {
 		return nil, errors.New("producer not found for topic: " + topic)
@@ -154,7 +154,7 @@ func (k *KafkaProducer) reconnect(ctx context.Context) error {
 	}
 	k.conn = kConn
 	// 将重连后的生产者放回连接池
-	producerPool.Store(getPoolKey(k.config, k.topic), k)
+	producerPool.Store(getPoolKey(k.config.Name, k.topic), k)
 	return nil
 }
 

--- a/queue/kafkax/producer.go
+++ b/queue/kafkax/producer.go
@@ -15,14 +15,23 @@ import (
 	"github.com/segmentio/kafka-go/sasl/plain"
 )
 
-var producerPool sync.Map // key: topic, value: *KafkaProducer
+var producerPool sync.Map // key: name:topic, value: *KafkaProducer
 
 type KafkaConfig struct {
 	Username  string
 	Password  string
 	GroupID   string
 	Brokers   string
-	EnableTLS bool // 是否启用 TLS，默认 false（不启用）
+	EnableTLS bool   // 是否启用 TLS，默认 false（不启用）
+	Name      string // 实例标识，用于区分多个 Kafka 实例，为空时兼容旧行为；如果项目有多个 Kafka 实例，请务必设置！
+}
+
+// getPoolKey 构造 producerPool 的 key
+func getPoolKey(c *KafkaConfig, topic string) string {
+	if c.Name == "" {
+		return topic // 向后兼容：未设置 Name 时退化为纯 topic
+	}
+	return c.Name + ":" + topic
 }
 
 type KafkaProducer struct {
@@ -35,7 +44,8 @@ type KafkaProducer struct {
 func InitProducerForTopics(ctx context.Context, c *KafkaConfig, topics []string) {
 	for _, topic := range topics {
 		producer := newKafkaProducerWithTopic(ctx, c, topic)
-		producerPool.LoadOrStore(topic, producer)
+		key := getPoolKey(c, topic)
+		producerPool.LoadOrStore(key, producer)
 		fmt.Println("Kafka producer initialized for topic:", topic)
 	}
 }
@@ -73,8 +83,9 @@ func newKafkaProducerWithTopic(ctx context.Context, c *KafkaConfig, topic string
 }
 
 // GetProducerByTopic 获取指定 topic 的 producer
-func GetProducerByTopic(topic string) (*KafkaProducer, error) {
-	val, ok := producerPool.Load(topic)
+func GetProducerByTopic(c *KafkaConfig, topic string) (*KafkaProducer, error) {
+	key := getPoolKey(c, topic)
+	val, ok := producerPool.Load(key)
 	if !ok {
 		return nil, errors.New("producer not found for topic: " + topic)
 	}
@@ -143,7 +154,7 @@ func (k *KafkaProducer) reconnect(ctx context.Context) error {
 	}
 	k.conn = kConn
 	// 将重连后的生产者放回连接池
-	producerPool.Store(k.topic, k)
+	producerPool.Store(getPoolKey(k.config, k.topic), k)
 	return nil
 }
 

--- a/queue/kafkax/producer_test.go
+++ b/queue/kafkax/producer_test.go
@@ -28,7 +28,7 @@ func TestKafkaProducerPublish(t *testing.T) {
 	InitProducerForTopics(ctx, cfg, []string{topic})
 
 	// 获取指定 topic 的 producer
-	producer, err := GetProducerByTopic(topic)
+	producer, err := GetProducerByTopic(cfg, topic)
 	if err != nil {
 		t.Fatalf("获取 producer 失败: %v", err)
 	}


### PR DESCRIPTION
- 在 KafkaConfig 中新增 Name 字段用于区分多个实例
- 修改 producerPool 的 key 结构为 name:topic，保持兼容旧行为
- 新增 getPoolKey 函数统一构造连接池 key
- 更新 InitProducerForTopics、GetProducerByTopic 和重连逻辑，使用新的 key 方案
- 修改测试代码，传入 KafkaConfig 以支持多实例查询